### PR TITLE
feat: add server_headers parameter to MinerUClient and HttpVlmClient

### DIFF
--- a/mineru_vl_utils/mineru_client.py
+++ b/mineru_vl_utils/mineru_client.py
@@ -266,6 +266,7 @@ class MinerUClient:
         backend: Literal["http-client", "transformers", "vllm-engine", "vllm-async-engine"],
         model_name: str | None = None,
         server_url: str | None = None,
+        server_headers: dict[str, str] | None = None,
         model=None,  # transformers model
         processor=None,  # transformers processor
         vllm_llm=None,  # vllm.LLM model
@@ -344,6 +345,7 @@ class MinerUClient:
             backend=backend,
             model_name=model_name,
             server_url=server_url,
+            server_headers=server_headers,
             model=model,
             processor=processor,
             vllm_llm=vllm_llm,

--- a/mineru_vl_utils/vlm_client/base_client.py
+++ b/mineru_vl_utils/vlm_client/base_client.py
@@ -144,6 +144,7 @@ def new_vlm_client(
     backend: Literal["http-client", "transformers", "vllm-engine", "vllm-async-engine"],
     model_name: str | None = None,
     server_url: str | None = None,
+    server_headers: dict[str, str] | None = None,
     model=None,  # transformers model
     processor=None,  # transformers processor
     vllm_llm=None,  # vllm.LLM model
@@ -166,6 +167,7 @@ def new_vlm_client(
         return HttpVlmClient(
             model_name=model_name,
             server_url=server_url,
+            server_headers=server_headers,
             prompt=prompt,
             system_prompt=system_prompt,
             sampling_params=sampling_params,


### PR DESCRIPTION
We need to be able to pass custom headers to the vllm server (ie api key). Will make a follow up pr on mineru after this is merged.