### PR TITLE
fix postprocess for mineru2.5-pro

### DIFF
--- a/mineru_vl_utils/post_process/__init__.py
+++ b/mineru_vl_utils/post_process/__init__.py
@@ -76,9 +76,9 @@ def post_process(
                 
         elif block.type == "text" and block.content:
             try:
+                block.content = try_convert_display_to_inline(block.content, debug=debug)
                 block.content = try_fix_macro_spacing_in_markdown(block.content, debug=debug)
                 block.content = try_move_underscores_outside(block.content, debug=debug)
-                block.content = try_convert_display_to_inline(block.content, debug=debug)
             except Exception as e:
                 print("Warning: Failed to process text: ", e)
                 print("Content: ", block.content)

--- a/mineru_vl_utils/post_process/__init__.py
+++ b/mineru_vl_utils/post_process/__init__.py
@@ -6,6 +6,10 @@ from .equation_fix_eqqcolon import try_fix_equation_eqqcolon
 from .equation_left_right import try_match_equation_left_right
 from .equation_leq import try_fix_equation_leq
 from .equation_unbalanced_braces import try_fix_unbalanced_braces
+from .equation_delimeters import try_fix_equation_delimeters
+from .text_inline_spacing import try_fix_macro_spacing_in_markdown
+from .text_display2inline import try_convert_display_to_inline
+from .text_move_underscores_outside import try_move_underscores_outside
 from .otsl2html import convert_otsl_to_html
 
 PARATEXT_TYPES = {
@@ -19,6 +23,7 @@ PARATEXT_TYPES = {
 
 
 def _process_equation(content: str, debug: bool) -> str:
+    content = try_fix_equation_delimeters(content, debug=debug)
     content = try_match_equation_left_right(content, debug=debug)
     content = try_fix_equation_double_subscript(content, debug=debug)
     content = try_fix_equation_eqqcolon(content, debug=debug)
@@ -57,7 +62,7 @@ def post_process(
     debug: bool = False,
 ) -> list[ContentBlock]:
     blocks = simple_process(blocks)
-
+    
     if simple_post_process:
         return blocks
 
@@ -67,6 +72,15 @@ def post_process(
                 block.content = _process_equation(block.content, debug=debug)
             except Exception as e:
                 print("Warning: Failed to process equation: ", e)
+                print("Content: ", block.content)
+                
+        elif block.type == "text" and block.content:
+            try:
+                block.content = try_fix_macro_spacing_in_markdown(block.content, debug=debug)
+                block.content = try_convert_display_to_inline(block.content, debug=debug)
+                block.content = try_move_underscores_outside(block.content, debug=debug)
+            except Exception as e:
+                print("Warning: Failed to process text: ", e)
                 print("Content: ", block.content)
 
     if handle_equation_block:

--- a/mineru_vl_utils/post_process/__init__.py
+++ b/mineru_vl_utils/post_process/__init__.py
@@ -77,8 +77,8 @@ def post_process(
         elif block.type == "text" and block.content:
             try:
                 block.content = try_fix_macro_spacing_in_markdown(block.content, debug=debug)
-                block.content = try_convert_display_to_inline(block.content, debug=debug)
                 block.content = try_move_underscores_outside(block.content, debug=debug)
+                block.content = try_convert_display_to_inline(block.content, debug=debug)
             except Exception as e:
                 print("Warning: Failed to process text: ", e)
                 print("Content: ", block.content)

--- a/mineru_vl_utils/post_process/equation_delimeters.py
+++ b/mineru_vl_utils/post_process/equation_delimeters.py
@@ -1,0 +1,17 @@
+def try_fix_equation_delimeters(latex: str, debug: bool = False) -> str:
+    
+    new_latex = latex.strip()
+    if new_latex[:2] == "\\[":
+        new_latex = new_latex[2:]
+    if new_latex[-2:] == "\\]":
+        new_latex = new_latex[:-2]
+    new_latex = new_latex.strip()
+    
+    if debug and new_latex != latex:
+        print(f"Fixed equation delimeters from: {latex} to: {new_latex}")
+    return new_latex
+
+
+if __name__ == "__main__":
+    latex = "\\[a \\coloneqq b\\]"
+    print(try_fix_equation_delimeters(latex))

--- a/mineru_vl_utils/post_process/text_display2inline.py
+++ b/mineru_vl_utils/post_process/text_display2inline.py
@@ -2,7 +2,14 @@ import re
 
 def try_convert_display_to_inline(text: str, debug: bool = False) -> str:
     
-    new_text = re.sub(r'\\\[(.+?)\\\]', r'\\(\1\\)', text, flags=re.DOTALL)
+    def replace(m):
+        inner = m.group(1)
+        if re.fullmatch(r'[–\d\-,\s]+', inner):
+            return r'\[' + inner + r'\]'
+        else:
+            return r'\(' + inner + r'\)'
+
+    new_text = re.sub(r'\\\[(.*?)\\\]', replace, text, flags=re.DOTALL)
     
     if debug and new_text != text:
         print(f"Fixed equation delimeters from: {text} to: {new_text}")

--- a/mineru_vl_utils/post_process/text_display2inline.py
+++ b/mineru_vl_utils/post_process/text_display2inline.py
@@ -1,0 +1,14 @@
+import re
+
+def try_convert_display_to_inline(text: str, debug: bool = False) -> str:
+    
+    new_text = re.sub(r'\\\[(.+?)\\\]', r'\\(\1\\)', text, flags=re.DOTALL)
+    
+    if debug and new_text != text:
+        print(f"Fixed equation delimeters from: {text} to: {new_text}")
+    
+    return new_text
+
+if __name__ == "__main__":
+    text = r"(B) \[ \begin{pmatrix}2&-1\\-1&2\end{pmatrix}. \]"
+    print(try_convert_display_to_inline(text))

--- a/mineru_vl_utils/post_process/text_inline_spacing.py
+++ b/mineru_vl_utils/post_process/text_inline_spacing.py
@@ -1,0 +1,49 @@
+import re
+
+def fix_macro_spacing(text, target_macros, known_macros=None):
+    if known_macros is None:
+        known_macros = set()
+
+    for macro in target_macros:
+        pattern = re.escape(macro) + r'([a-zA-Z])(?![a-zA-Z])'
+
+        def replace(m, macro=macro):
+            letter = m.group(1)
+            if (macro + letter) in known_macros:
+                return m.group(0)
+            return macro + ' ' + letter
+
+        text = re.sub(pattern, replace, text)
+
+    return text
+
+def try_fix_macro_spacing_in_markdown(text, debug: bool = False) -> str:
+    """
+    只处理 \\( ... \\) 包裹的公式部分，普通文本不动。
+    """
+    
+    known_macros = {r'\top', r'\int'}
+    target_macros = [r'\cong', r'\to', r'\times', r'\subset', r'\in']
+    
+    result = []
+    # 按 \\( ... \\) 分割，奇数 index 为公式内容
+    parts = re.split(r'(\\\(.*?\\\))', text, flags=re.DOTALL)
+
+    for i, part in enumerate(parts):
+        if part.startswith(r'\(') and part.endswith(r'\)'):
+            # 只处理公式内部内容，保留首尾定界符
+            inner = part[2:-2]
+            fixed_inner = fix_macro_spacing(inner, target_macros, known_macros)
+            result.append(r'\(' + fixed_inner + r'\)')
+        else:
+            result.append(part)
+
+    new_text = ''.join(result)
+    
+    if debug and new_text != text:
+        print(f"Fixed equation delimeters from: {text} to: {new_text}")
+    return new_text
+
+if __name__ == "__main__":
+    text = "abcdf \\( a \\timesX b \\) asdadfads"
+    print(try_fix_macro_spacing_in_markdown(text))

--- a/mineru_vl_utils/post_process/text_inline_spacing.py
+++ b/mineru_vl_utils/post_process/text_inline_spacing.py
@@ -22,7 +22,7 @@ def try_fix_macro_spacing_in_markdown(text, debug: bool = False) -> str:
     只处理 \\( ... \\) 包裹的公式部分，普通文本不动。
     """
     
-    known_macros = {r'\top', r'\int'}
+    known_macros = {r'\top', r'\int', r'\inf'}
     target_macros = [r'\cong', r'\to', r'\times', r'\subset', r'\in']
     
     result = []

--- a/mineru_vl_utils/post_process/text_move_underscores_outside.py
+++ b/mineru_vl_utils/post_process/text_move_underscores_outside.py
@@ -27,6 +27,6 @@ def try_move_underscores_outside(text: str, debug: bool = False) -> str:
 
 if __name__ == "__main__":
     # text = r"(13) 设  \( z = \left(\frac{y}{x}\right)^{\frac{x}{y}} \) ，则  \( \frac{\partial z}{\partial x}\bigg|_{(1,2)} = ____ \) ."
-    # text = r"xxx = \( ___ = \lambda \)"
+    text = r"xxx = \( \sigma ___ = \lambda \)"
     
     print(try_move_underscores_outside(text))

--- a/mineru_vl_utils/post_process/text_move_underscores_outside.py
+++ b/mineru_vl_utils/post_process/text_move_underscores_outside.py
@@ -1,0 +1,32 @@
+import re
+
+def try_move_underscores_outside(text: str, debug: bool = False) -> str:
+    def process_match(m):
+        inner = m.group(1)
+        # 按 3+ 个连续下划线分割
+        parts = re.split(r'(_{3,})', inner)
+
+        if len(parts) == 1:
+            return m.group(0)  # 没有下划线，不处理
+
+        result = []
+        for part in parts:
+            if re.fullmatch(r'_{3,}', part):
+                result.append(part)          # 下划线放到外面，作为纯文本
+            elif part.strip():
+                result.append(r'\(' + part + r'\)')  # 剩余公式内容重新包裹
+
+        return ' '.join(result)
+    
+    new_text = re.sub(r'\\\((.+?)\\\)', process_match, text, flags=re.DOTALL)
+    
+    if debug and new_text != text:
+        print(f"Fixed equation delimeters from: {text} to: {new_text}")
+    
+    return new_text
+
+if __name__ == "__main__":
+    # text = r"(13) 设  \( z = \left(\frac{y}{x}\right)^{\frac{x}{y}} \) ，则  \( \frac{\partial z}{\partial x}\bigg|_{(1,2)} = ____ \) ."
+    # text = r"xxx = \( ___ = \lambda \)"
+    
+    print(try_move_underscores_outside(text))


### PR DESCRIPTION
后处理针对MinerU2.5-pro增加以下修改，
针对行间公式：
1. 偶尔有情况输出公式带\\[\\]分隔符
针对行内公式：
1. 偶尔有行内公式粘连的情况，例如\\timesR
2. 行内公式中包含连续多个____下划线符号，无法渲染，移动到\\(\\)外边
3. 偶有行内公式用\\[\\]作为分隔符