### PR TITLE
docs(README): add SGLang serving option

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,31 @@ You still can serve the model without logits processor:
 vllm serve opendatalab/MinerU2.5-2509-1.2B --host 127.0.0.1 --port 8000
 ```
 
+### Alternatively, serve with SGLang
+
+MinerU2.5 is a `Qwen2VLForConditionalGeneration` model, which SGLang serves
+natively, so you can also serve it with SGLang and connect through the
+`http-client` backend:
+
+```bash
+python3 -m sglang.launch_server \
+  --model-path opendatalab/MinerU2.5-2509-1.2B \
+  --host 127.0.0.1 --port 30000
+```
+
+On newer SGLang releases the `sglang serve opendatalab/MinerU2.5-2509-1.2B
+--host 127.0.0.1 --port 30000` entrypoint alias also works. Neither
+`--trust-remote-code` nor `--chat-template` is required.
+
+> SGLang does not support the `no_repeat_ngram_size` sampling param, so unlike
+> the vllm path there is no `MinerULogitsProcessor` equivalent applied — the
+> `http-client` backend sends the param inside `vllm_xargs` and the SGLang
+> server silently ignores it. This is fine for clean documents (output matches
+> the vllm/transformers paths); repetition is only mitigated by the default
+> `presence_penalty`/`frequency_penalty`. For stricter control, launch SGLang
+> with `--enable-custom-logit-processor` and port the n-gram block through its
+> custom logit processor mechanism.
+
 ## Using `MinerUClient` by Code
 
 Now you can use the `MinerUClient` class to interact with the model.


### PR DESCRIPTION
## What

Adds an **SGLang** option to the "Serving the Model (Optional)" section of the README, alongside the existing `vllm serve` instructions.

MinerU2.5 is a `Qwen2VLForConditionalGeneration` model, which SGLang serves natively. Users on SGLang infrastructure can therefore serve it with SGLang's OpenAI-compatible server and drive it through `mineru-vl-utils`' existing `http-client` backend — no code change in this library.

## Note included

The new subsection states honestly that SGLang has no `no_repeat_ngram_size` sampling param, so unlike the vLLM path there is no `MinerULogitsProcessor` equivalent applied automatically (the param sent via `vllm_xargs` is ignored). This is fine for clean documents; for stricter control the note points to SGLang's `--enable-custom-logit-processor`.

Verified end-to-end: `MinerUClient(backend="http-client", server_url=...)` → SGLang server running `opendatalab/MinerU2.5-2509-1.2B` produces correct layout/extraction output (OmniDocBench v1.6 on par with the vLLM path).
