### PR TITLE
Treat missing content key as empty string, not a hard error

### DIFF
--- a/mineru_vl_utils/vlm_client/http_client.py
+++ b/mineru_vl_utils/vlm_client/http_client.py
@@ -328,9 +328,7 @@ class HttpVlmClient(VlmClient):
         message = choices[0].get("message")
         if not isinstance(message, dict):
             raise ServerError("Message not found in the response.")
-        if "content" not in message:
-            raise ServerError("Content not found in the message.")
-        content = message["content"]
+        content = message.get("content") or ""
         if not (content is None or isinstance(content, str)):
             raise ServerError(f"Unexpected content type: {type(content)}.")
         # Allow the end token to be configured via environment variable, falling back to the default.


### PR DESCRIPTION
Treat missing content key as empty string, not a hard error